### PR TITLE
Use ActiveSupport::CurrentAttributes to store input payload

### DIFF
--- a/io_to_response_payload_ratio.gemspec
+++ b/io_to_response_payload_ratio.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency "rails", ">= 6.0"
-  spec.add_dependency "concurrent-ruby", "~> 1.0"
 end

--- a/lib/io_to_response_payload_ratio/aggregator.rb
+++ b/lib/io_to_response_payload_ratio/aggregator.rb
@@ -1,50 +1,46 @@
 # frozen_string_literal: true
 
-require "concurrent"
-
 module IoToResponsePayloadRatio
   # Thread-safe payload size aggregator.
   class Aggregator
     def initialize(sources)
       @sources = sources
-      @active = Concurrent::ThreadLocalVar.new(false)
-      @state = Concurrent::ThreadLocalVar.new(empty_state)
     end
 
     attr_reader :sources
 
     def active?
-      active.value
+      InputPayload.active.present?
     end
 
     def start!
-      active.value = true
+      InputPayload.active = true
     end
 
     def stop!
-      active.value = false
-    end
-
-    def reset!
-      state.value = empty_state
+      InputPayload.active = false
     end
 
     def increment(source, val)
       return unless active?
 
-      state.value[source.to_sym] += val
+      InputPayload.state ||= empty_state
+      InputPayload.state[source.to_sym] += val
     end
 
     def get(source)
-      state.value[source.to_sym]
+      InputPayload.state ||= empty_state
+      InputPayload.state[source.to_sym]
     end
 
     private
 
-    attr_reader :active, :state
-
     def empty_state
       sources.map { |kind| [kind, 0] }.to_h
+    end
+
+    class InputPayload < ActiveSupport::CurrentAttributes
+      attribute :state, :active
     end
   end
 end

--- a/lib/io_to_response_payload_ratio/controller.rb
+++ b/lib/io_to_response_payload_ratio/controller.rb
@@ -5,7 +5,6 @@ module IoToResponsePayloadRatio
     extend ActiveSupport::Concern
 
     def process_action(*)
-      IoToResponsePayloadRatio.aggregator.reset!
       IoToResponsePayloadRatio.aggregator.start!
 
       super

--- a/spec/io_to_response_payload_ratio/adapters/active_record_adapter_spec.rb
+++ b/spec/io_to_response_payload_ratio/adapters/active_record_adapter_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe IoToResponsePayloadRatio::ActiveRecordAdapter do
   end
 
   before do
-    aggregator.reset!
     aggregator.start!
   end
 

--- a/spec/io_to_response_payload_ratio/aggregator_spec.rb
+++ b/spec/io_to_response_payload_ratio/aggregator_spec.rb
@@ -25,17 +25,6 @@ RSpec.describe IoToResponsePayloadRatio::Aggregator do
     end
   end
 
-  describe ".reset!" do
-    it "nullifies the state" do
-      aggregator.start!
-      aggregator.increment(sources.first, 42)
-      aggregator.stop!
-      aggregator.reset!
-
-      expect(aggregator.get(sources.first)).to eq(0)
-    end
-  end
-
   describe ".increment" do
     it "increments the specified source value" do
       aggregator.start!
@@ -66,7 +55,6 @@ RSpec.describe IoToResponsePayloadRatio::Aggregator do
 
     Thread.new do
       aggregator.start!
-      aggregator.reset!
 
       expect(aggregator.get(sources.first)).to eq(0)
       expect(aggregator.active?).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@ require "rspec/rails"
 require "io_to_response_payload_ratio"
 
 RSpec.configure do |config|
+  # For proper work of ActiveSupport::CurrentAttributes reset
+  config.include ActiveSupport::CurrentAttributes::TestHelper
+
   config.example_status_persistence_file_path = ".rspec_status"
   config.infer_base_class_for_anonymous_controllers = true
 


### PR DESCRIPTION
`ActiveSupport::CurrentAttributes` resets attributes automatically before and after each request. Can be used with thread-local and fiber-local variables.

I think in this case we won't get much from automatic attributes reset because we sets default values before every request in any case. But it can be useful for fiber compatibility and we can get rid of one dependency.